### PR TITLE
Made noise display buckets more granular

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -149,6 +149,7 @@ limitations under the License. -->
                                 <option value="5">5</option>
                                 <option value="10">10</option>
                                 <option value="100" selected>100</option>
+                                <option value="500">500</option>
                                 <option value="1000">1000</option>
                                 <option value="10000">10000</option>
                                 <option value="100000">100000</option>
@@ -268,6 +269,7 @@ limitations under the License. -->
                             <option value="5">5</option>
                             <option value="10">10</option>
                             <option value="100">100</option>
+                            <option value="500">500</option>
                             <option value="1000" selected>1000</option>
                             <option value="10000">10000</option>
                             <option value="100000">100000</option>

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-export const APP_VERSION = 'v2.5.1'
+export const APP_VERSION = 'v2.5.2'
 
 export const MODES = {
     simple: {

--- a/public/js/dom.js
+++ b/public/js/dom.js
@@ -387,12 +387,18 @@ export function displaySimulationResults_simpleMode(
 }
 
 function getNoiseBadgeType(noiseValue) {
-    if (noiseValue >= 20) {
+    if (noiseValue >= 100) {
+        return 'over-100'
+    } else if (noiseValue >= 20) {
         return 'over-20'
+    } else if (noiseValue >= 15) {
+        return 'over-15'
+    } else if (noiseValue >= 10) {
+        return 'over-10'
     } else if (noiseValue >= 5) {
-        return 'between-5-20'
+        return 'over-5'
     } else if (noiseValue >= 1) {
-        return 'under-5'
+        return 'over-1'
     } else {
         return 'under-1'
     }

--- a/public/style.css
+++ b/public/style.css
@@ -246,23 +246,38 @@ main {
     font-size: 110%;
 }
 
+.over-100::after {
+    background-color: rgb(0, 0, 0);
+    content: '> 100%';
+}
+
 .over-20::after {
-    background-color: rgb(255, 111, 0);
-    content: '> 20%';
+    background-color: rgb(207, 34, 0);
+    content: '20% - 100%';
 }
 
-.between-5-20::after {
-    background-color: rgb(137, 59, 0);
-    content: '5% - 20%';
+.over-15::after {
+    background-color: rgb(254, 97, 0);
+    content: '15% - 20%';
 }
 
-.under-5::after {
-    background-color: rgb(80, 35, 0);
+.over-10::after {
+    background-color: rgb(181, 21, 229);
+    content: '10% - 15%';
+}
+
+.over-5::after {
+    background-color: rgb(121, 32, 216);
+    content: '5% - 10%';
+}
+
+.over-1::after {
+    background-color: rgb(35, 32, 216);
     content: '1% - 5%';
 }
 
 .under-1::after {
-    background-color: black;
+    background-color: #2361ff;
     content: '< 1%';
 }
 


### PR DESCRIPTION
Up until now, values like 6% and 19% have the same badge, and values like 21% and 300% have the same badge. 
Added more badges and colors to reflect such differences more prominently and make it easier to analyze noise at a glance.

Tested this new color palette to be colorblind-friendly.

Colors:

<img width="399" alt="image" src="https://user-images.githubusercontent.com/9762897/224681741-20ea0f05-8c25-4281-93ee-2d0b6a2b6c2a.png">

<img width="389" alt="image" src="https://user-images.githubusercontent.com/9762897/224681906-850f28fa-da77-4ecc-ad2c-1a5af0f2e7e8.png">

<img width="404" alt="image" src="https://user-images.githubusercontent.com/9762897/224681386-71055929-4037-4e6e-bfb5-753a294ca4ea.png">

<img width="390" alt="image" src="https://user-images.githubusercontent.com/9762897/224682080-fd5558bc-57ff-4267-ae79-28f1e73103d0.png">




With color blindness (pronatopia):
<img width="394" alt="image" src="https://user-images.githubusercontent.com/9762897/224681308-f7e7360b-3c6c-4e64-b016-5349acd3c3b0.png">
