### PR TITLE
Refactor: Outlined post-refactoring code structure

### DIFF
--- a/public/js/_unified.js
+++ b/public/js/_unified.js
@@ -1,0 +1,91 @@
+let allSimulationTables = {}
+
+function initialize() {
+    loadPython()
+    initializeDisplay()
+}
+
+export function downloadAll_advancedMode() {
+    downloadAll(allSimulationDataTables_advancedMode)
+}
+
+// UI
+function resetUi() {
+    // reset form validation
+    // clear output
+    resetFormValidation()
+    clearSimulationArea()
+}
+function resetFormValidation() {
+    const formValidationWrapperEl = getFormValidationElFromDom()
+    if (formValidationWrapperEl) {
+        formValidationWrapperEl.innerText = ''
+        formValidationWrapperEl.className = 'hidden'
+    }
+}
+function clearSimulationArea() {
+    // Prompt user to confirm
+    if (window.confirm(generateConfirmMessage())) {
+        // TODO check absence of mode OK
+        document.getElementById(`all-simulations-wrapper`).innerHTML = ''
+    }
+    displayEmptyState(mode)
+}
+
+// Tables
+function saveSimulationAsTable(table, tableTitle) {
+    allSimulationTables = {
+        ...allSimulationTables,
+        // tableTitle includes the simulation Id
+        [`${tableTitle}`]: table,
+    }
+}
+function downloadAllSimulationsAsTables() {
+    const dummyTableId = Object.keys(allSimulationDataTables)[0]
+    const dummyTable = allSimulationTables[dummyTableId]
+    // This is a hack; the TabulatorFull lib seems to have a bug where the first table isn't displayed unless we use the `table: true` syntax below
+    delete allSimulationTables[dummyTableId]
+
+    const d = new Date()
+    dummyTable.download(
+        'xlsx',
+        `Noise Lab ${d.toLocaleTimeString()} ${d.toLocaleDateString()}.xlsx`,
+        {
+            sheets: {
+                [`${dummyTableId}`]: true,
+                ...allSimulationTables,
+            },
+        }
+    )
+}
+
+// Actual simulation
+function simulate() {
+    // const simulation = generateSimulation()
+    // displaySimulation(simulation)
+}
+function generateSimulation() {}
+
+// simulation object
+const simulation = {
+    data: {
+        report: [],
+        noiseMetrics: {
+            noise_ape: 12,
+            noise_ape_percent: 12,
+            noise_rmspe: 12,
+            noise_rmspe_percent: 12,
+        },
+    },
+    metadata: {
+        // TODO rename to 'id'
+        simulationId: 123,
+        measurementGoalDisplayName: 'dfgh',
+        scalingFactor: 123,
+        keyCombinationString: 'werewrew',
+    },
+    // TODO remove once made unnecessary
+    simulationNo,
+    // TODO remove once made unnecessary
+    metricsNo,
+}

--- a/public/js/_unified.js
+++ b/public/js/_unified.js
@@ -5,10 +5,6 @@ function initialize() {
     initializeDisplay()
 }
 
-export function downloadAll_advancedMode() {
-    downloadAll(allSimulationDataTables_advancedMode)
-}
-
 // UI
 function resetUi() {
     // reset form validation

--- a/public/js/_unified.js
+++ b/public/js/_unified.js
@@ -63,25 +63,57 @@ function simulate() {
 function generateSimulation() {}
 
 // simulation object
+// One simulation is per goal
 const simulation = {
-    data: {
-        report: [],
-        noiseMetrics: {
-            noise_ape: 12,
-            noise_ape_percent: 12,
-            noise_rmspe: 12,
-            noise_rmspe_percent: 12,
-        },
-    },
     metadata: {
         // TODO rename to 'id'
-        simulationId: 123,
-        measurementGoalDisplayName: 'dfgh',
-        scalingFactor: 123,
-        keyCombinationString: 'werewrew',
+        simulationTitle: 'Simulation 13:30:27 05/07/2023',
+        simulationId: 'e3b77a88',
     },
-    // TODO remove once made unnecessary
-    simulationNo,
-    // TODO remove once made unnecessary
-    metricsNo,
+    inputParameters: {
+        dailyConversionCount: '100',
+        dimensions: [
+            {
+                name: 'campaignId',
+                numberOfDistinctValues: 4,
+            },
+        ],
+        epsilon: '10',
+        keyStrategy: 'A',
+        metrics: [
+            {
+                id: 2,
+                name: 'purchaseCount',
+                maxValue: 1,
+                avgValue: 1,
+            },
+        ],
+        batchingFrequency: '1',
+        isUseScaling: true,
+    },
+    outputReports: [
+        {
+            data: [
+                {
+                    key: [0, 0, 0],
+                    summaryValue: 12000,
+                    summaryValue_scaled_noiseless: 393599.99999999994,
+                    summaryValue_scaled_noisy: 389797.99999999994,
+                    noise: 23232, // NEW for simple
+                    noise_ape_individual: 0.009659552845528456,
+                },
+            ],
+            noiseMetrics: {
+                noise_ape_percent: 1.508,
+                noise_rmsre: 0.02115,
+            },
+            scalingFactor: 32.8,
+            measurementGoal: 'purchaseValue', // formerly "title"
+            dimensionsString: 'campaignId x geography x productCategory', // formerly keyCombinationString
+        },
+        // Another report { ... }
+    ],
+    // Used for table display to disambiguate / Have unique IDs
+    simulationNo: 1,
+    metricsNo: 1,
 }


### PR DESCRIPTION
@cucuandreea FYI 

This is my proposed structure for the code post-refactoring, i.e. post-unifying `simple` and `advanced` mode. Both modes would use the functions in that file. With some parametrization when strictly needed: 
* UI initialization is different across modes, because dimensions and keys can be customized in `advanced` and not in `simple`
* Displaying simulation results may vary a bit too across modes

But the rest should be the same.

PTAL in particular at the `simulation` object. 
WDYT?